### PR TITLE
X maturity aware test runs with complex test data

### DIFF
--- a/Dockerfile_RENCI_PRODUCTION
+++ b/Dockerfile_RENCI_PRODUCTION
@@ -8,6 +8,7 @@ RUN pip install --no-cache-dir --upgrade -r /code/requirements-service.txt
 COPY translator /code/translator
 COPY tests /code/tests
 COPY api /code/api
+COPY *.env /code
 # allow non root user write access to tests dir
 RUN chown nru:nru /code/tests
 # use non root user

--- a/Dockerfile_SIMPLE
+++ b/Dockerfile_SIMPLE
@@ -8,5 +8,6 @@ RUN pip install --no-cache-dir --upgrade -r /code/requirements-service.txt
 COPY translator /code/translator
 COPY tests /code/tests
 COPY api /code/api
+COPY *.env /code
 EXPOSE 8090
 CMD ["uvicorn", "api.main:app", "--proxy-headers", "--host", "0.0.0.0", "--port", "8090"]

--- a/api/main.py
+++ b/api/main.py
@@ -128,6 +128,12 @@ class TestRunParameters(BaseModel):
     # designating a KP which is the target of validation in the new test run.
     kp_id: Optional[str] = None
 
+    # (Optional) x_maturity environment target for test run. We assume here that any and both ARA and KP
+    # specified above have servers block endpoints specified under the corresponding 'x-maturity' tag in
+    # their respective Translator SmartAPI Registry entry 'servers' block.
+    # If unspecified, then SRI Testing makes an educated guess of which 'x-maturity' endpoint to test.
+    x_maturity: Optional[str] = None
+
     # (Optional) TRAPI version override against which
     # SRI Testing will be applied to Translator KPs and ARA's.
     # This version will override Translator SmartAPI Registry
@@ -208,6 +214,7 @@ async def run_tests(test_parameters: Optional[TestRunParameters] = None) -> Test
     infores identifier being filtered. Note that all identifiers here should be the reference (object)
     identifiers of the Infores CURIE of the target resource(s).
 
+    - **x_maturity**: Optional[str], **x_maturity** environment target for test run (system chooses if not specified)
     - **trapi_version**: Optional[str], possible TRAPI version overriding Translator SmartAPI 'Registry' specification.
     - **biolink_version**: Optional[str], possible Biolink Model version overriding Registry specification.
     - **timeout**: Optional[int], query timeout
@@ -219,6 +226,7 @@ async def run_tests(test_parameters: Optional[TestRunParameters] = None) -> Test
 
     ara_id: Optional[str] = None
     kp_id: Optional[str] = None
+    x_maturity: Optional[str] = None
     trapi_version: Optional[str] = None
     biolink_version: Optional[str] = None
     log: Optional[str] = None
@@ -232,6 +240,9 @@ async def run_tests(test_parameters: Optional[TestRunParameters] = None) -> Test
 
         if test_parameters.kp_id:
             kp_id = test_parameters.kp_id
+
+        if test_parameters.x_maturity:
+            x_maturity = test_parameters.x_maturity
 
         if test_parameters.trapi_version:
             trapi_version = test_parameters.trapi_version
@@ -264,6 +275,7 @@ async def run_tests(test_parameters: Optional[TestRunParameters] = None) -> Test
     test_harness.run(
         ara_id=ara_id,
         kp_id=kp_id,
+        x_maturity=x_maturity,
         trapi_version=trapi_version,
         biolink_version=biolink_version,
         log=log,

--- a/api/main.py
+++ b/api/main.py
@@ -67,8 +67,8 @@ async def favicon():
 
 class ResourceRegistry(BaseModel):
     message: str = ""
-    KPs: List[str]
-    ARAs: List[str]
+    KPs: Dict[str, List[str]]
+    ARAs: Dict[str, List[str]]
 
 
 @app.get(
@@ -82,16 +82,20 @@ async def get_resources_from_registry() -> ResourceRegistry:
     Returns a list of ARA and KP available for testing from the Translator SmartAPI Registry.
     Note that only Translator resources with their **info.x-trapi.test_data_location** properties set are reported.
 
-    - 2-Tuple(List[ara_id*], List[kp_id*]) of the reference ('object') id's of InfoRes CURIES of available KPs and ARAs.
+    - 2-Tuple(Dict[ara_id*, List[str], Dict[kp_id*, List[str]) inventory of available KPs and ARAs,vkeyed with the
+      reference ('object') id's of InfoRes CURIES and values are lists of testable x-maturity environments
     \f
-    :return: ResourceRegistry, Lists of Reference ('object') id's of InfoRes CURIES of available KPs and ARAs.
+    :return: ResourceRegistry, inventory of available KPs and ARAs with the testable x-maturity environment types.
     """
-    resources: Optional[Tuple[List[str], List[str]]] = OneHopTestHarness.get_resources_from_registry()
+    resources: Optional[Tuple[Dict[str, List[str]], Dict[str, List[str]]]] = \
+        OneHopTestHarness.testable_resources_catalog_from_registry()
+
     message: str
     if resources:
         message = "Translator resources found!"
     else:
         message = "Translator SmartAPI Registry currently offline?"
+
     return ResourceRegistry(message=message, KPs=resources[0], ARAs=resources[1])
 
 

--- a/api/main.py
+++ b/api/main.py
@@ -784,6 +784,8 @@ async def get_code_entry(
         distinct: bool = False
 ) -> Union[ValidationCodes, JSONResponse]:
     """
+    Retrieves validation distinct validation message code or a subtree (for partial code paths).
+    Either the message template and/or description 'facet' of the code may be returned.
 
     :param code: str, 'dot' path specified code identifier from reasoner-validator codes.yaml validation message codes.
     :param facet: Optional[str], constraint on code entry facet to be returned; if specified,

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,4 @@ pymongo
 kgx
 linkml
 bmt>=0.8.12
-reasoner-validator>=3.2.2
-
+reasoner-validator>=3.2.3

--- a/tests/onehop/README.md
+++ b/tests/onehop/README.md
@@ -225,6 +225,14 @@ e.g.
 pytest -vv test_onehops.py --ara_id=arax --kp_id=molepro
 ```
 
+## Translator X-Maturity Environments
+
+To constrain testing to one specific x-maturity environment (say, 'testing'), use the **`--x_maturity`** directive:
+
+```
+pytest -vv test_onehops.py --ara_id=arax --kp_id=molepro --x_maturity=testing
+```
+
 ## Test CLI Help
 
 The full set of the currently available command line options may be viewed using the help function:
@@ -245,6 +253,9 @@ The above SRI Testing-specific parameters are described as PyTest custom options
   --kp_id=KP_ID         Knowledge Provider identifier ("KP") targeted for testing (Default: None).
  
   --ara_id=ARA_ID       Autonomous Relay Agent ("ARA") targeted for testing (Default: None).
+  
+  --x_maturity=X_MATURITY
+                        Target x_maturity server environment for testing (Default: None).
   
   --teststyle=TESTSTYLE Which Test to Run?
   

--- a/tests/onehop/README.md
+++ b/tests/onehop/README.md
@@ -26,10 +26,10 @@ The default operation of SRI Testing now relies on the interrogation of the Tran
 
 - **info.x-translator.biolink-version:** _must_ be set to the actual Biolink Model release to which the given KP or ARA is asserting compliance. Validation to the 'wrong' Biolink Model version will generate unnecessary validation errors!
 - **info.x-trapi.version:** _must_ be set to the TRAPI version to which the given KP or ARA is asserting compliance.
-- **info.x-trapi.test_data_location:** see the full specification of the [info.x-trapi.test_data_location](https://github.com/NCATSTranslator/translator_extensions#x-trapi) for the range of formats now available for specifying SRI Testing harness test or configuration data files. URL's registered in whatever fashion within the **info.x-trapi.test_data_location:** values can typically (although not necessarily) be a URL to a Github public repository hosted file (note: this can be 'rawdata' URL or a regular Github URL - the latter is automatically rewritten to a 'rawdata' access for file retrieval). If a non-Github URL is given, it should be visible on the internet without authentication.
-- **servers block:** the SRI Testing harness now sets the TRAPI server endpoint used for testing of KP and ARA resources by selecting a **`url`** specified in the Registry `servers` block. Lack of standardization of testing targets means that the system is currently agnostic about **`x-maturity`** but simply takes the first **`servers`** block entry with a '**`url`**' property set. If there is more than one server entry in the **`servers`** block, then the wrong testing endpoint may be used. Note that future iterations of the system may follow a different heuristic using the **`x-maturity`** property.
+- **info.x-trapi.test_data_location:** see the full specification of the [info.x-trapi.test_data_location](https://github.com/NCATSTranslator/translator_extensions#x-trapi) for the range of formats now available for specifying SRI Testing harness test or configuration data files. URL's registered in whatever fashion within the **info.x-trapi.test_data_location:** values can typically (although not necessarily) be a URL to a Github public repository hosted file (note: this can be 'rawdata' URL or a regular Github URL - the latter is automatically rewritten to a 'rawdata' access for file retrieval). If a non-Github URL is given, it should be visible on the internet without authentication.  Lists of test data files (urls) are all functionally merged into a single set of test edges (annotated by test data knowledge source) for a given KP or ARA/KP component test suite.
+- **servers block:** the SRI Testing harness now sets the TRAPI server endpoint used for testing of KP and ARA resources by selecting a **`url`** specified in the Registry `servers` block. 
 
-**Note:** the **info.x-trapi.test_data_location** may change in the near future to accommodate the need for differential testing across various `x-maturity` deployments of KPs and ARAs.
+Every test run only tests **_one_** endpoint within **_one_** **`x-maturity`** environment. The target **`x-maturity`** environment may now be explicitly specified as a **`/test_run`** API parameter. If omitted, then the **`x-maturity`** is selected based on available `servers` entries in the precedence ordering of '`production`', '`staging`', '`testing`' and '`development`'.  Since the Translator community has deemed all endpoints specified as equivalent when belonging to a specified **`x-maturity`**, the system simply selects the first live ('online') endpoint (ascertained by querying its TRAPI **`/meta_knowledge_graph`** API) within the given **`x-maturity`** list of endpoints. Note that future iterations of the system may revise the above selection heuristics based on Translator community policy decisions.
 
 ### KP Test Data Format
 
@@ -196,8 +196,10 @@ For each ARA, we want to ensure that it is able to extract information correctly
     #
     # Optional KP test data format version. Generally assume 'latest' if not given. 
     # This particular version is deemed version 2.0 which implies major support focused
-    # on Biolink major version 2 (i.e. 2.#.# releases)
-    "version": "2.0"
+    # on Biolink major version 2 (i.e. 2.#.# releases). At this point in time, however,
+    # ARA support of Biolink 3.0 does not dictate any ARA test configuration file changes,
+    # This, a "version" tag for the file is optional here.
+    # "version": "2.0"
     
     #
     # Deprecated: the 'url' field is no longer used to set the endpoint (see Registry comments above)

--- a/tests/onehop/conftest.py
+++ b/tests/onehop/conftest.py
@@ -53,33 +53,51 @@ def _new_kp_test_case_summary(trapi_version: str, biolink_version: str) -> Dict[
     return new_test_case_summary
 
 
-def _new_kp_resource_summary(trapi_version: str, biolink_version: str) -> Dict[str, Union[str, Dict]]:
+def _new_kp_resource_summary(
+        url: str,
+        x_maturity: str,
+        trapi_version: str,
+        biolink_version: str
+) -> Dict[str, Union[str, Dict]]:
     """
     Initialize a dictionary to capture statistics for a single KP test case summary.
 
+    :param url: str, KP or ARA component endpoint being tested
+    :param x_maturity: str, x-maturity environment within which the tested url is hosted
     :param trapi_version: str, TRAPI version associated with the test case (SemVer)
     :param biolink_version:  str, Biolink Model version associated with the test case (SemVer)
 
     :return: Dict[str, Union[int, str, Dict]], initialized
     """
-    new_test_case_summary: Dict[str, Union[str, Dict]] = {
+    kp_resource_summary: Dict[str, Union[str, Dict]] = {
+        'url': url,
+        'x_maturity': x_maturity,
         'trapi_version': trapi_version,
         'biolink_version': biolink_version,
         'test_edges': dict()
     }
-    return new_test_case_summary
+    return kp_resource_summary
 
 
-def _new_kp_recommendation_summary(trapi_version: str, biolink_version: str) -> Dict[str, Union[str, Dict]]:
+def _new_kp_recommendation_summary(
+        url: str,
+        x_maturity: str,
+        trapi_version: str,
+        biolink_version: str
+) -> Dict[str, Union[str, Dict]]:
     """
     Initialize a dictionary to capture recommendations for a single KP test case summary.
 
+    :param url: str, KP or ARA component endpoint being tested
+    :param x_maturity: str, x-maturity environment within which the tested url is hosted
     :param trapi_version: str, TRAPI version associated with the test case (SemVer)
     :param biolink_version:  str, Biolink Model version associated with the test case (SemVer)
 
     :return: Dict[str, Union[int, str, Dict]], initialized
     """
     new_recommendations: Dict[str, Union[str, Dict]] = {
+        'url': url,
+        'x_maturity': x_maturity,
         'trapi_version': trapi_version,
         'biolink_version': biolink_version,
         'errors': dict(),
@@ -288,10 +306,14 @@ def pytest_sessionfinish(session):
                     biolink_version=biolink_version
                 )
                 resource_summaries[component][ara_id][kp_id] = _new_kp_resource_summary(
+                    url=url,
+                    x_maturity=x_maturity,
                     trapi_version=trapi_version,
                     biolink_version=biolink_version
                 )
                 recommendation_summaries[component][ara_id][kp_id] = _new_kp_recommendation_summary(
+                    url=url,
+                    x_maturity=x_maturity,
                     trapi_version=trapi_version,
                     biolink_version=biolink_version
                 )
@@ -311,10 +333,14 @@ def pytest_sessionfinish(session):
                 test_run_summary[component][kp_id]['test_data_location'] = test_case['ks_test_data_location']
 
                 resource_summaries[component][kp_id] = _new_kp_resource_summary(
+                    url=url,
+                    x_maturity=x_maturity,
                     trapi_version=trapi_version,
                     biolink_version=biolink_version
                 )
                 recommendation_summaries[component][kp_id] = _new_kp_recommendation_summary(
+                    url=url,
+                    x_maturity=x_maturity,
                     trapi_version=trapi_version,
                     biolink_version=biolink_version
                 )

--- a/tests/onehop/conftest.py
+++ b/tests/onehop/conftest.py
@@ -743,6 +743,7 @@ def get_kp_metadata(
     x_maturity: Optional[str] = metafunc.config.getoption('x_maturity')
 
     if x_maturity and x_maturity.lower() not in ["production", "staging", "testing", "development"]:
+        # Sanity check....
         x_maturity = None
 
     # Note: the KP's trapi_version and biolink_version may be overridden here
@@ -760,11 +761,11 @@ def get_kp_metadata(
         # attention to KPs indicated by test configuration as called by that ARA?
         # Since we don't want to pop the metadata from its dictionary but
         # don't know the ara_id, we need to use a for loop to access it
-        for ara_source, ara_metadata in ara_metadata.items():
+        for ara_source, metadata in ara_metadata.items():
 
             # TODO: with x-maturity environments and the possibility of a list
             #       of test data files, the arajson may not soon be what it seems!
-            arajson: Dict = load_test_data_source(ara_metadata)
+            arajson: Dict = load_test_data_source(metadata)
 
             kps: Set[str] = {kp_id for kp_id in arajson['KPs']}
 
@@ -793,7 +794,7 @@ def generate_trapi_kp_tests(metafunc, kp_metadata) -> List:
 
         # TODO: with x-maturity environments and the possibility of a list
         #       of test data files, the kpjson may not soon be what it seems!
-        kpjson = load_test_data_source(metadata)
+        kpjson: Dict = load_test_data_source(metadata)
 
         if not kpjson:
             # valid test data file not found?
@@ -940,7 +941,7 @@ def generate_trapi_ara_tests(metafunc, kp_edges, ara_metadata):
 
         # TODO: with x-maturity environments and the possibility of a list
         #       of test data files, the arajson may not soon be what it seems!
-        arajson = load_test_data_source(metadata)
+        arajson: Dict = load_test_data_source(metadata)
 
         if not arajson:
             # valid test data file not found?

--- a/tests/onehop/conftest.py
+++ b/tests/onehop/conftest.py
@@ -559,7 +559,7 @@ def get_test_data_sources(
 
     :param source: Optional[str], ara_id or kp_id source of test configuration data in the registry.
                                   Take 'all' of the given component type if the source is None
-                                  
+
     :param x_maturity: Optional[str], x_maturity environment target for test run (system chooses if not specified)
     :param component_type: str, component type 'KP' or 'ARA'
     :param trapi_version: SemVer caller override of TRAPI release target for validation (Default: None)
@@ -570,7 +570,7 @@ def get_test_data_sources(
     # Access service metadata from the Translator SmartAPI Registry,
     # indexed using the "test_data_location" field as the unique key
     registry_data: Dict = get_the_registry_data()
-    service_metadata = extract_component_test_metadata_from_registry(registry_data, component_type, source)
+    service_metadata = extract_component_test_metadata_from_registry(registry_data, component_type, source, x_maturity)
 
     # Possible CLI override of the metadata value of
     # TRAPI and/or Biolink Model releases used for data validation

--- a/tests/onehop/test_triples/ARA/ARAX/ARAX_Lite.json
+++ b/tests/onehop/test_triples/ARA/ARAX/ARAX_Lite.json
@@ -1,5 +1,6 @@
 {
     "url": "https://arax.ncats.io/api/arax/v1.3",
+    "infores": "arax",
     "KPs": [
         "infores:molepro"
     ]

--- a/tests/onehop/util.py
+++ b/tests/onehop/util.py
@@ -71,6 +71,11 @@ def create_one_hop_message(edge, look_up_subject: bool = False) -> Dict:
 #
 #####################################################################################################
 _unit_tests: Dict = dict()
+_unit_test_definitions: Dict = dict()
+
+
+def get_unit_test_definitions() -> Dict:
+    return _unit_test_definitions.copy()
 
 
 def get_unit_test_codes() -> Set[str]:
@@ -113,11 +118,12 @@ class TestCode:
     """
     Assigns a shorthand test code to a unit test method.
     """
-    def __init__(self, code, unit_test_name):
+    def __init__(self, code: str, unit_test_name: str, description: str):
         global _unit_tests
         self.code = code
         self.method = unit_test_name
         _unit_tests[code] = unit_test_name
+        _unit_test_definitions[unit_test_name] = description
 
     def __call__(self, fn):
         @wraps(fn)
@@ -127,14 +133,23 @@ class TestCode:
         return wrapper
 
 
-@TestCode("BS", "by_subject")
+@TestCode(
+    code="BS",
+    unit_test_name="by_subject",
+    description="Given a known triple, create a TRAPI message that looks up the object by the subject"
+)
 def by_subject(request):
     """Given a known triple, create a TRAPI message that looks up the object by the subject"""
     message = create_one_hop_message(request)
     return message, 'object', 'b'
 
 
-@TestCode("IBNS", "inverse_by_new_subject")
+@TestCode(
+    code="IBNS",
+    unit_test_name="inverse_by_new_subject",
+    description="Given a known triple, create a TRAPI message that inverts the predicate, " +
+                "then looks up the new object by the new subject (original object)"
+)
 def inverse_by_new_subject(request):
     """Given a known triple, create a TRAPI message that inverts the predicate,
        then looks up the new object by the new subject (original object)"""
@@ -175,7 +190,11 @@ def inverse_by_new_subject(request):
     return message, 'subject', 'b'
 
 
-@TestCode("BO", "by_object")
+@TestCode(
+    code="BO",
+    unit_test_name="by_object",
+    description="Given a known triple, create a TRAPI message that looks up the subject by the object"
+)
 def by_object(request):
     """Given a known triple, create a TRAPI message that looks up the subject by the object"""
     message = create_one_hop_message(request, look_up_subject=True)
@@ -197,7 +216,14 @@ def no_parent_error(unit_test_name: str, element: Dict, suffix: Optional[str] = 
     return None, context, reason
 
 
-@TestCode("RSE", "raise_subject_entity")
+@TestCode(
+    code="RSE",
+    unit_test_name="raise_subject_entity",
+    description="Given a known triple, create a TRAPI message that uses a parent instance " +
+                "of the original entity and looks up the object. This only works if a given " +
+                "instance (category) has an identifier (prefix) namespace bound to some kind " +
+                "of hierarchical class of instances (i.e. ontological structure)"
+)
 def raise_subject_entity(request):
     """
     Given a known triple, create a TRAPI message that uses
@@ -220,7 +246,12 @@ def raise_subject_entity(request):
     return message, 'object', 'b'
 
 
-@TestCode("ROBS", "raise_object_by_subject")
+@TestCode(
+    code="ROBS",
+    unit_test_name="raise_object_by_subject",
+    description="Given a known triple, create a TRAPI message that uses the parent " +
+                "of the original object category and looks up the object by the subject"
+)
 def raise_object_by_subject(request):
     """
     Given a known triple, create a TRAPI message that uses the parent
@@ -244,7 +275,12 @@ def raise_object_by_subject(request):
     return message, 'object', 'b'
 
 
-@TestCode("RPBS", "raise_predicate_by_subject")
+@TestCode(
+    code="RPBS",
+    unit_test_name="raise_predicate_by_subject",
+    description="Given a known triple, create a TRAPI message that uses the parent " +
+                "of the original predicate and looks up the object by the subject"
+)
 def raise_predicate_by_subject(request):
     """
     Given a known triple, create a TRAPI message that uses the parent

--- a/tests/translator/registry/__init__.py
+++ b/tests/translator/registry/__init__.py
@@ -38,8 +38,10 @@ MOCK_TRANSLATOR_SMARTAPI_REGISTRY_METADATA = {
                 "x-trapi": {
                     "version": "1.3.0",
                     "test_data_location": {
-                        "testing": "https://raw.githubusercontent.com/monarch-initiative/" +
+                        "testing": {
+                            "url": "https://raw.githubusercontent.com/monarch-initiative/" +
                                    "monarch-plater-docker/main/test_data/sri_reference_kg_test_data.json"
+                        }
                     }
                 }
             },
@@ -73,8 +75,10 @@ MOCK_TRANSLATOR_SMARTAPI_REGISTRY_METADATA = {
                 },
                 'x-trapi': {
                      'test_data_location': {
-                         'testing': 'https://github.com/broadinstitute/molecular-data-provider/' +
+                         'testing': {
+                             'url': 'https://github.com/broadinstitute/molecular-data-provider/' +
                                     'blob/master/test/data/MolePro-test-data.json'
+                         }
                      },
                      'version': '1.3.0'
                  }
@@ -129,8 +133,10 @@ MOCK_TRANSLATOR_SMARTAPI_REGISTRY_METADATA = {
                     # 'test_data_location': 'https://raw.githubusercontent.com/RTXteam/RTX/' +
                     #                       'master/code/ARAX/Documentation/arax_kps.json',
                     'test_data_location': {
-                        'testing': 'https://raw.githubusercontent.com/TranslatorSRI/SRI_testing/' +
+                        'testing': {
+                            'url': 'https://raw.githubusercontent.com/TranslatorSRI/SRI_testing/' +
                                    'main/tests/onehop/test_triples/ARA/ARAX/ARAX_Lite.json'
+                        }
                     },
                     'version': '1.3.0'
                 }

--- a/tests/translator/registry/__init__.py
+++ b/tests/translator/registry/__init__.py
@@ -78,6 +78,10 @@ MOCK_TRANSLATOR_SMARTAPI_REGISTRY_METADATA = {
                          'testing': {
                              'url': 'https://github.com/broadinstitute/molecular-data-provider/' +
                                     'blob/master/test/data/MolePro-test-data.json'
+                         },
+                         'staging': {
+                             'url': 'https://github.com/broadinstitute/molecular-data-provider/' +
+                                    'blob/master/test/data/MolePro-test-data.json'
                          }
                      },
                      'version': '1.3.0'
@@ -134,6 +138,10 @@ MOCK_TRANSLATOR_SMARTAPI_REGISTRY_METADATA = {
                     #                       'master/code/ARAX/Documentation/arax_kps.json',
                     'test_data_location': {
                         'testing': {
+                            'url': 'https://raw.githubusercontent.com/TranslatorSRI/SRI_testing/' +
+                                   'main/tests/onehop/test_triples/ARA/ARAX/ARAX_Lite.json'
+                        },
+                        'staging': {
                             'url': 'https://raw.githubusercontent.com/TranslatorSRI/SRI_testing/' +
                                    'main/tests/onehop/test_triples/ARA/ARAX/ARAX_Lite.json'
                         }

--- a/tests/translator/registry/__init__.py
+++ b/tests/translator/registry/__init__.py
@@ -141,7 +141,7 @@ MOCK_TRANSLATOR_SMARTAPI_REGISTRY_METADATA = {
                             'url': 'https://raw.githubusercontent.com/TranslatorSRI/SRI_testing/' +
                                    'main/tests/onehop/test_triples/ARA/ARAX/ARAX_Lite.json'
                         },
-                        'staging': {
+                        'production': {
                             'url': 'https://raw.githubusercontent.com/TranslatorSRI/SRI_testing/' +
                                    'main/tests/onehop/test_triples/ARA/ARAX/ARAX_Lite.json'
                         }

--- a/tests/translator/registry/test_translator_registry.py
+++ b/tests/translator/registry/test_translator_registry.py
@@ -1099,7 +1099,7 @@ def test_extract_ara_test_data_metadata_from_registry(query: Tuple[Dict, str, st
     ]
 )
 def test_validate_testable_resource(query: Tuple):
-    resource_metadata: Optional[Dict[str, Union[str, List, Dict]]] = \
+    resource_metadata: Optional[Dict[str, Union[str, List]]] = \
         validate_testable_resource(1, query[0], "ARA")
     if query[1]:
         assert 'url' in resource_metadata
@@ -1139,25 +1139,6 @@ def test_get_one_specific_target_kp():
         assert "https://molepro-trapi.transltr.io/molepro/trapi/v1.3" in service["url"]
 
 
-def test_get_one_specific_multi_url_target_kp():
-    registry_data: Dict = get_the_registry_data()
-    # we filter on the 'sri-reference-kg' since it is used both in the mock and real registry?
-    service_metadata = extract_component_test_metadata_from_registry(
-        registry_data, "KP", source="service-provider-trapi"
-    )
-    assert len(service_metadata) == 1, "We're expecting at least one but not more than one source KP here!"
-    for service in service_metadata.values():
-        assert service["infores"] == "service-provider-trapi"
-        assert "https://bte.transltr.io/v1/team/Service%20Provider" in service["url"]
-        assert len(service["test_data_location"]) > 1
-        assert isinstance(service["test_data_location"], Dict)
-        for x_maturity, urls in service["test_data_location"].items():
-            if x_maturity == 'default':
-                assert len(urls) > 1
-                assert "https://raw.githubusercontent.com/NCATS-Tangerine/translator-api-registry/master/" + \
-                       "biothings_explorer/sri-test-service-provider.json" in urls
-
-
 def test_get_translator_ara_test_data_metadata():
     registry_data: Dict = get_the_registry_data()
     service_metadata = extract_component_test_metadata_from_registry(registry_data=registry_data, component_type="ARA")
@@ -1175,6 +1156,7 @@ def test_get_one_specific_target_ara():
         # the 'url' setting should be a list that includes urls from
         # the default 'production' x-maturity servers list
         assert "https://arax.transltr.io/api/arax/v1.3" in service["url"]
+        assert service["x_maturity"] == "production"
 
 
 def test_get_one_specific_target_x_maturity_in_a_target_ara():

--- a/tests/translator/registry/test_translator_registry.py
+++ b/tests/translator/registry/test_translator_registry.py
@@ -935,3 +935,20 @@ def test_get_one_specific_target_ara():
     assert len(service_metadata) == 1, "We're expecting at least one but not more than one source ARA here!"
     for service in service_metadata.values():
         assert service["infores"] == "arax"
+        # the 'url' setting should be a list that includes urls from
+        # the default 'production' x-maturity servers list
+        assert "https://arax.transltr.io/api/arax/v1.3" in service["url"]
+
+
+def test_get_one_specific_target_x_maturity_in_a_target_ara():
+    registry_data: Dict = get_the_registry_data()
+    # we filter on the 'arax' since it is used both in the mock and real registry?
+    service_metadata = extract_component_test_metadata_from_registry(
+        registry_data, "ARA", source="arax", x_maturity="testing"
+    )
+    assert len(service_metadata) == 1, "We're expecting at least one but not more than one source ARA here!"
+    for service in service_metadata.values():
+        assert service["infores"] == "arax"
+        # the 'url' setting should be a list that includes urls from
+        # the explicitly requested 'testing' x-maturity servers list
+        assert "https://arax.test.transltr.io/api/arax/v1.3" in service["url"]

--- a/tests/translator/registry/test_translator_registry.py
+++ b/tests/translator/registry/test_translator_registry.py
@@ -90,44 +90,55 @@ def test_get_default_url(query: Tuple[Optional[Union[str, List, Dict]], str]):
 
 
 # def select_endpoint(
-#         server_urls: Dict,
+#         server_urls: Dict[str, List],
 #         test_data_location: Optional[Union[str, List, Dict]]
 # ) -> Optional[Tuple[str, str]]
 @pytest.mark.parametrize(
     "query",
     [
-        (dict(), "", None),
-        (dict(), list(), None),
-        (dict(), dict(), None),
-        (
+        (dict(), "", None),  # Query 0: empty parameters - variant 1
+        (dict(), list(), None),  # Query 1: empty parameters - variant 2
+        (dict(), dict(), None),  # Query 2: empty parameters - variant 3
+        (   # Query 3 - complete server_urls for all x-maturity; simple string URL text_data_location
             {
-                'testing': "http://testing_endpoint",
-                'development': "http://development_endpoint",
-                'production': "http://production_endpoint",
-                'staging': "http://staging_endpoint"
+                'testing': ["http://testing_endpoint"],
+                'development': ["http://development_endpoint"],
+                'production': ["http://production_endpoint"],
+                'staging': ["http://staging_endpoint"]
             },
             "http://test_data",
-            ("http://production_endpoint", "production")
+            (
+                "http://production_endpoint",
+                "production",
+                "http://test_data"
+            )
         ),
-        (
+        (   # Query 4 - complete server_urls for all x-maturity; direct list of string URLs text_data_location
             {
-                'testing': "http://testing_endpoint",
-                'development': "http://development_endpoint",
-                'production': "http://production_endpoint",
-                'staging': "http://staging_endpoint"
+                'testing': ["http://testing_endpoint"],
+                'development': ["http://development_endpoint"],
+                'production': ["http://production_endpoint"],
+                'staging': ["http://staging_endpoint"]
             },
             [
                 "http://test_data_1",
                 "http://test_data_2",
             ],
-            ("http://production_endpoint", "production")
+            (
+                "http://production_endpoint",
+                "production",
+                [
+                    "http://test_data_1",
+                    "http://test_data_2",
+                ]
+            )
         ),
-        (
+        (   # Query 5 - complete server_urls for all x-maturity; full JSON object text_data_location without 'default'
             {
-                'testing': "http://testing_endpoint",
-                'development': "http://development_endpoint",
-                'production': "http://production_endpoint",
-                'staging': "http://staging_endpoint"
+                'testing': ["http://testing_endpoint"],
+                'development': ["http://development_endpoint"],
+                'production': ["http://production_endpoint"],
+                'staging': ["http://staging_endpoint"]
             },
             {
                 'testing': "http://testing_test_data",
@@ -135,76 +146,123 @@ def test_get_default_url(query: Tuple[Optional[Union[str, List, Dict]], str]):
                 'production': "http://production_test_data",
                 'staging': "http://staging_test_data"
             },
-            ("http://production_endpoint", "production")
+            (
+                "http://production_endpoint",
+                "production",
+                "http://production_test_data"
+            )
         ),
-        (
+        (   # Query 6 - complete server_urls for all x-maturity; JSON object text_data_location with just 'default'
             {
-                'testing': "http://testing_endpoint",
-                'development': "http://development_endpoint",
-                'production': "http://production_endpoint",
-                'staging': "http://staging_endpoint"
+                'testing': ["http://testing_endpoint"],
+                'development': ["http://development_endpoint"],
+                'production': ["http://production_endpoint"],
+                'staging': ["http://staging_endpoint"]
             },
             {
                 'default': "http://default_test_data"
             },
-            ("http://production_endpoint", "production")
+            (
+                "http://production_endpoint",
+                "production",
+                "http://default_test_data"
+            )
         ),
-        (
+        (   # Query 7 - partial server_urls for x-maturity; JSON object text_data_location with just 'default'
             {
-                'testing': "http://testing_endpoint",
-                'staging': "http://staging_endpoint"
+                'testing': ["http://testing_endpoint"],
+                'staging': ["http://staging_endpoint"]
             },
             {
                 'default': "http://default_test_data"
             },
-            ("http://staging_endpoint", "staging")
+            (
+                "http://staging_endpoint",
+                "staging",
+                "http://default_test_data"
+            )
         ),
-        (
+        (   # Query 8 - partial server_urls for x-maturity; non-overlapping object text_data_location without 'default'
             {
-                'testing': "http://testing_endpoint",
-                'production': "http://production_endpoint",
-                'staging': "http://staging_endpoint"
+                'testing': ["http://testing_endpoint"],
+                'production': ["http://production_endpoint"],
+                'staging': ["http://staging_endpoint"]
             },
             {
                 'development': "http://development_test_data"
             },
             None
         ),
-        (
+        (   # Query 9 - partial server_urls for x-maturity; non-overlapping object text_data_location with 'default'
             {
-                'testing': "http://testing_endpoint",
-                'staging': "http://staging_endpoint"
+                'testing': ["http://testing_endpoint"],
+                'staging': ["http://staging_endpoint"]
             },
             {
                 'default': "http://default_test_data",
                 'development': "http://development_test_data"
             },
-            ("http://staging_endpoint", "staging")
+            (
+                "http://staging_endpoint",
+                "staging",
+                "http://default_test_data"
+            )
         ),
-        (
+        (   # Query 10 - full server_urls for x-maturity; JSON object text_data_location with only one x-maturity
             {
-                'testing': "http://testing_endpoint",
-                'development': "http://development_endpoint",
-                'production': "http://production_endpoint",
-                'staging': "http://staging_endpoint"
+                'testing': ["http://testing_endpoint"],
+                'development': ["http://development_endpoint"],
+                'production': ["http://production_endpoint"],
+                'staging': ["http://staging_endpoint"]
             },
             {
                 'development': "http://development_test_data"
             },
-            ("http://development_endpoint", "development")
+            (
+                "http://development_endpoint",
+                "development",
+                "http://development_test_data"
+            )
         ),
-        (
+        (   # Query 11 - full server_urls for x-maturity; JSON object text_data_location with one x-maturity + default
             {
-                'testing': "http://testing_endpoint",
-                'development': "http://development_endpoint",
-                'production': "http://production_endpoint",
-                'staging': "http://staging_endpoint"
+                'testing': ["http://testing_endpoint"],
+                'development': ["http://development_endpoint"],
+                'production': ["http://production_endpoint"],
+                'staging': ["http://staging_endpoint"]
             },
             {
                 'default': "http://default_test_data",
                 'development': "http://development_test_data"
             },
-            ("http://development_endpoint", "development")
+            (
+                "http://development_endpoint",
+                "development",
+                "http://development_test_data"
+            )
+        ),
+        (   # Query 12 - full server_urls for x-maturity;
+            #            JSON object text_data_location with one x-maturity  with list of test data URLs
+            {
+                'testing': ["http://testing_endpoint"],
+                'development': ["http://development_endpoint"],
+                'production': ["http://production_endpoint"],
+                'staging': ["http://staging_endpoint"]
+            },
+            {
+                'development': [
+                    "http://development_test_data_1",
+                    "http://development_test_data_2"
+                ]
+            },
+            (
+                "http://development_endpoint",
+                "development",
+                [
+                    "http://development_test_data_1",
+                    "http://development_test_data_2"
+                ]
+            )
         )
     ]
 )

--- a/tests/translator/sri/testing/test_util.py
+++ b/tests/translator/sri/testing/test_util.py
@@ -1,8 +1,11 @@
 """
 Unit tests for OneHop unit test processing functions
 """
+from typing import Dict
+
 import pytest
 
+from tests.onehop.util import get_unit_test_definitions
 from translator.sri.testing.onehops_test_runner import (
     parse_unit_test_name,
     build_resource_summary_key,
@@ -116,3 +119,12 @@ def test_clean_up_unit_test_filename(query):
     assert part[3] == query[4]  # int(edge_num)
     assert part[4] == query[5]  # test_id
     assert part[5] == query[6]  # edge_details_file_path
+
+
+def test_get_unit_test_catalog():
+    catalog: Dict = get_unit_test_definitions()
+    assert catalog
+    assert "by_subject" in catalog.keys()
+    assert catalog["by_subject"] == "Given a known triple, create a TRAPI message " + \
+                                    "that looks up the object by the subject"
+

--- a/translator/registry/__init__.py
+++ b/translator/registry/__init__.py
@@ -489,7 +489,7 @@ def validate_testable_resource(
         service: Dict,
         component: str,
         x_maturity: Optional[str] = None
-) -> Optional[Dict[str, Union[str, List, Dict]]]:
+) -> Optional[Dict[str, Union[str, List]]]:
     """
 
     :param index: int, internal sequence number (i.e. hit number in the Translator SmartAPI Registry)
@@ -599,7 +599,10 @@ def validate_testable_resource(
         url, x_maturity, test_data = testable_system
         resource_metadata['url'] = url
         resource_metadata['x_maturity'] = x_maturity
-        resource_metadata['test_data_location'] = test_data
+        if isinstance(test_data, List):
+            resource_metadata['test_data_location'] = test_data
+        else:
+            resource_metadata['test_data_location'] = [test_data]
     else:
         # not likely, but another sanity check!
         logger.warning(f"Service {str(index)} has incomplete testable system parameters... Skipped?")
@@ -734,8 +737,10 @@ def extract_component_test_metadata_from_registry(
         service_title: str = resource_metadata['service_title']
         infores: str = resource_metadata['infores']
 
-        # this 'url' is the service endpoint
+        # this 'url' is the service endpoint in the
+        # specified 'x_maturity' environment
         url: str = resource_metadata['url']
+        x_maturity: str = resource_metadata['x_maturity']
 
         # The 'test_data_location' also has url's but these are now expressed
         # in a polymorphic manner: Optional[Dict[str, Union[str, List, Dict]]].
@@ -787,11 +792,12 @@ def extract_component_test_metadata_from_registry(
         _service_catalog[service_id].append(entry_id)
 
         capture_tag_value(service_metadata, service_id, "url", url)
+        capture_tag_value(service_metadata, service_id, "x_maturity", x_maturity)
         capture_tag_value(service_metadata, service_id, "service_title", service_title)
         capture_tag_value(service_metadata, service_id, "service_version", service_version)
         capture_tag_value(service_metadata, service_id, "component", component_type)
         capture_tag_value(service_metadata, service_id, "infores", infores)
-        capture_tag_value(service_metadata, service_id, "test_data_location", test_data_location)  # may be complex!
+        capture_tag_value(service_metadata, service_id, "test_data_location", test_data_location)
         capture_tag_value(service_metadata, service_id, "biolink_version", biolink_version)
         capture_tag_value(service_metadata, service_id, "trapi_version", trapi_version)
 

--- a/translator/registry/__init__.py
+++ b/translator/registry/__init__.py
@@ -198,7 +198,7 @@ def validate_url(url: str) -> Optional[str]:
     # Simple URL string to validate
     if not url.startswith('http'):
         logger.error(
-            f"validate_test_data_location(): Simple string test_data_location " + \
+            f"validate_test_data_locations(): Simple string test_data_location " + \
             f"'{url}' is not a valid URL?"
         )
     #
@@ -206,7 +206,7 @@ def validate_url(url: str) -> Optional[str]:
     # extensions to their test data, so we relax this constraint on test data files.
     #
     # elif not url.endswith('json'):
-    #     logger.error(f"validate_test_data_location(): JSON Resource " +
+    #     logger.error(f"validate_test_data_locations(): JSON Resource " +
     #                  f"'{url}' expected to have a 'json' file extension?")
     else:
         # Sanity check: rewrite 'regular' Github page endpoints to
@@ -222,11 +222,11 @@ def validate_url(url: str) -> Optional[str]:
                 return test_data_location
             else:
                 logger.error(
-                    f"validate_test_data_location(): '{test_data_location}' access " +
+                    f"validate_test_data_locations(): '{test_data_location}' access " +
                     f"returned http status code: {request.status_code}?"
                 )
         except RequestException as re:
-            logger.error(f"validate_test_data_location(): exception {str(re)}?")
+            logger.error(f"validate_test_data_locations(): exception {str(re)}?")
 
     return None
 
@@ -298,7 +298,7 @@ def parse_test_environment_urls(test_environments: Dict) -> Optional[Dict]:
     (option 2 format discussed in https://github.com/TranslatorSRI/SRI_testing/issues/59#issuecomment-1275136793).
 
     :param test_environments: Dict, complex specification of test_data_location (see schema)
-    :return: Optional[Dict], an x-maturity indexed URL catalog
+    :return: Optional[Dict], an x-maturity indexed URL catalog (including 'default' values)
     """
     valid_urls: Dict = dict()
     for x_maturity in test_environments.keys():
@@ -317,7 +317,7 @@ def parse_test_environment_urls(test_environments: Dict) -> Optional[Dict]:
     return valid_urls
 
 
-def validate_test_data_location(
+def validate_test_data_locations(
         test_data_location: Optional[Union[str, List, Dict]]
 ) -> Optional[Union[str, List, Dict]]:
     """
@@ -328,7 +328,8 @@ def validate_test_data_location(
     """
     try:
         if not test_data_location:
-            logger.error(f"validate_test_data_location(): empty URL?")
+            logger.error(f"validate_test_data_locations(): empty URL?")
+            return None
 
         elif isinstance(test_data_location, Dict):
             # Parse in an instance of the new extended JSON object data model for info.x-trapi.test_data_location.
@@ -484,69 +485,24 @@ def select_endpoint(
         return None
 
 
-def validate_testable_resource(
-        index: int,
+def validate_servers(
+        infores: str,
         service: Dict,
-        component: str,
         x_maturity: Optional[str] = None
-) -> Optional[Dict[str, Union[str, List]]]:
+) -> Optional[Dict[str, List[str]]]:
     """
-    Validates a service as testable and resolves then returns parameters for testing.
+    Validate the servers block, returning it or None if unavailable.
 
-    :param index: int, internal sequence number (i.e. hit number in the Translator SmartAPI Registry)
-    :param service: Dict, indexed metadata about a component service (from the Registry)
-    :param component: str, type of component, one of 'KP' or 'ARA'
-    :param x_maturity: Optional[str], 'x_maturity' environment target for test run (system chooses if not specified)
-    :return: augmented resource metadata for a given KP or ARA service confirmed to be 'testable'; None if unavailable
+    :param infores: str, InfoRes reference id of the service
+    :param service: Dict, service metadata (from Registry)
+    :param x_maturity: Optional[str], target x-maturity (if set; may be None if not unconstrained)
+    :return: Dict, catalog of x-maturity environment servers; None if unavailable.
     """
-    #
-    # This 'overloaded' function actually checks a number of parameters that need to be present for testable resources.
-    # If the validation of all parameters succeeds, it returns a dictionary of those values; otherwise, returns 'None'
-    #
-    resource_metadata: Dict = dict()
-
-    service_title = tag_value(service, "info.title")
-    if service_title:
-        resource_metadata['service_title'] = service_title
-    else:
-        logger.warning(f"Registry {component} entry '{str(index)}' lacks a 'service_title'... Skipped?")
-        return None
-
-    if not ('servers' in service and service['servers']):
-        logger.warning(f"Registry {component} entry '{service_title}' lacks a 'servers' block... Skipped?")
-        return None
-
-    infores = tag_value(service, "info.x-translator.infores")
-    # Internally, within SRI Testing, we only track the object_id of the infores CURIE
-    infores = infores.replace("infores:", "") if infores else None
-
-    if infores:
-        resource_metadata['infores'] = infores
-    else:
-        logger.warning(f"Registry {component} entry '{service_title}' has no 'infores' identifier. Skipping?")
-        return None
-
-    if infores in _ignored_resources:
-        logger.warning(
-            f"Registry {component} entry '{service_title}' with InfoRes '{infores}' is tagged to be ignored. Skipping?"
-        )
-        return None
-
-    raw_test_data_location: Optional[Union[str, Dict]] = tag_value(service, "info.x-trapi.test_data_location")
-
-    # ... and only interested in resources with a non-empty, valid, accessible test_data_location specified
-    test_data_location: Optional[Union[str, List, Dict]] = validate_test_data_location(raw_test_data_location)
-    if test_data_location:
-        # Optional[Union[str, List, Dict]], may be a single URL string, an array of URL string's,
-        # or an x-maturity indexed catalog of URLs (single or List of URL string(s))
-        resource_metadata['test_data_location'] = test_data_location
-    else:
-        logger.warning(
-            f"Empty, invalid or inaccessible 'info.x-trapi.test_data_location' specification "
-            f"'{str(raw_test_data_location)}' for Registry {component} entry '{service_title}'! Service entry skipped?")
-        return None
-
     servers: Optional[List[Dict]] = service['servers']
+
+    if not servers:
+        logger.warning(f"Registry entry '{infores}' missing a 'servers' block? Skipping...")
+        return None
 
     server_urls: Dict = dict()
     for server in servers:
@@ -572,22 +528,168 @@ def validate_testable_resource(
         env_endpoint = server['url']
         if environment not in server_urls:
             # first url seen for a given for a given x-maturity
-            logger.info(
-                f"Registry {component} entry '{service_title}' server endpoint "
-                f"for environment '{environment}' set to url '{env_endpoint}'."
-            )
             server_urls[environment] = list()
 
+        logger.info(
+            f"Registry entry '{infores}' x-maturity '{environment}' includes  url '{env_endpoint}'."
+        )
         server_urls[environment].append(env_endpoint)
 
-    # By the time we are here, we either have a single selected
-    # x_maturity or None (if a specific x_maturity was set)...
+    return server_urls
+
+
+def get_testable_resource(
+        index: int,
+        service: Dict
+) -> Optional[Tuple[str, List[str]]]:
+    """
+    Validates a service as testable and resolves then returns parameters for testing.
+
+    :param index: int, internal sequence number (i.e. hit number in the Translator SmartAPI Registry)
+    :param service: Dict, indexed metadata about a component service (from the Registry)
+    :return: Optional[Tuple[str, List[str]]], composed of the infores reference id and
+             List of associated 'testable' x_maturities; None if unavailable
+    """
+    infores = tag_value(service, "info.x-translator.infores")
+    if not infores:
+        logger.warning(f"Registry entry '{index}' has no 'infores' identifier. Skipping?")
+        return None
+    else:
+        # Internally, within SRI Testing, we only track the object_id of the infores CURIE
+        infores = infores.replace("infores:", "")
+
+    if not ('servers' in service and service['servers']):
+        logger.warning(f"Registry '{index}' entry '{infores}' lacks a 'servers' block... Skipped?")
+        return None
+
+    raw_test_data_location: Optional[Union[str, Dict]] = tag_value(service, "info.x-trapi.test_data_location")
+
+    # ... and only interested in resources with a non-empty, valid, accessible test_data_location specified
+    test_data_location: Optional[Union[str, List, Dict]] = validate_test_data_locations(raw_test_data_location)
+    if not test_data_location:
+        logger.warning(
+            f"Empty, invalid or inaccessible 'info.x-trapi.test_data_location' specification "
+            f"'{str(raw_test_data_location)}' for Registry '{index}' entry  '{infores}'! Untestable service skipped?")
+        return None
+
+    is_default: bool = False
+    if isinstance(test_data_location, str) or isinstance(test_data_location, List):
+        is_default = True
+    else:
+        if 'default' in test_data_location:
+            is_default = True
+
+    servers: List[Dict] = service['servers']
+    server_urls: Dict = validate_servers(infores=infores, service=service)
+
+    # By the time we are here, we either have a one selected
+    # x_maturity environments or None (if a specific x_maturity was set) or,
+    # if no such x_maturity preference, a catalog of (possibly one selected)
+    # available 'x_maturity' environments from which to select for testing.
     # We filter out the latter situation first...
     if not server_urls:
         return None
 
-    # ...or (if no such x_maturity preference), a catalog of (possibly one selected)
+    x_maturities: List[str] = list()
+
+    if is_default:
+        # if there is a default, then all servers are deemed
+        # testable even if they may have specific test data
+        x_maturities = list(server_urls.keys())
+    else:
+        # Otherwise, find intersection set between server_urls and test_data_location x-maturities
+        for x_maturity in server_urls.keys():
+            if x_maturity in test_data_location:
+                x_maturities.append(x_maturity)
+
+    if x_maturities:
+        return infores, x_maturities
+    else:
+        # no intersecting set of servers and
+        # test_data_location x_maturities?
+        return None
+
+
+def validate_testable_resource(
+        index: int,
+        service: Dict,
+        component: str,
+        x_maturity: Optional[str] = None
+) -> Optional[Dict[str, Union[str, List]]]:
+    """
+    Validates a service as testable and resolves then returns parameters for testing.
+
+    :param index: int, internal sequence number (i.e. hit number in the Translator SmartAPI Registry)
+    :param service: Dict, indexed metadata about a component service (from the Registry)
+    :param component: str, type of component, one of 'KP' or 'ARA'
+    :param x_maturity: Optional[str], 'x_maturity' environment target for test run (system chooses if not specified)
+    :return: augmented resource metadata for a given KP or ARA service confirmed to be 'testable'
+             for one selected x-maturity environment; None if unavailable
+    """
+    #
+    # This 'overloaded' function actually checks a number of parameters that need to be present for testable resources.
+    # If the validation of all parameters succeeds, it returns a dictionary of those values; otherwise, returns 'None'
+    #
+    resource_metadata: Dict = dict()
+
+    service_title = tag_value(service, "info.title")
+    if service_title:
+        resource_metadata['service_title'] = service_title
+    else:
+        logger.warning(f"Registry {component} entry '{str(index)}' lacks a 'service_title'... Skipped?")
+        return None
+
+    if not ('servers' in service and service['servers']):
+        logger.warning(f"Registry {component} entry '{service_title}' lacks a 'servers' block... Skipped?")
+        return None
+
+    infores = tag_value(service, "info.x-translator.infores")
+
+    # Internally, within SRI Testing, we only track the object_id of the infores CURIE
+    infores = infores.replace("infores:", "") if infores else None
+
+    if infores:
+        resource_metadata['infores'] = infores
+    else:
+        logger.warning(f"Registry entry '{infores}' has no 'infores' identifier. Skipping?")
+        return None
+
+    if infores in _ignored_resources:
+        logger.warning(
+            f"Registry entry '{infores}' is tagged to be ignored. Skipping?"
+        )
+        return None
+
+    raw_test_data_location: Optional[Union[str, Dict]] = tag_value(service, "info.x-trapi.test_data_location")
+
+    # ... and only interested in resources with a non-empty, valid, accessible test_data_location specified
+    test_data_location: Optional[Union[str, List, Dict]] = validate_test_data_locations(raw_test_data_location)
+    if test_data_location:
+        # Optional[Union[str, List, Dict]], may be a single URL string, an array of URL string's,
+        # or an x-maturity indexed catalog of URLs (single or List of URL string(s))
+        resource_metadata['test_data_location'] = test_data_location
+    else:
+        logger.warning(
+            f"Empty, invalid or inaccessible 'info.x-trapi.test_data_location' specification "
+            f"'{str(raw_test_data_location)}' for Registry entry '{infores}'! Service entry skipped?")
+        return None
+
+    servers: Optional[List[Dict]] = service['servers']
+
+    if not servers:
+        logger.warning(f"Registry entry '{infores}' missing a 'servers' block? Skipping...")
+        return None
+
+    server_urls: Dict = validate_servers(infores=infores, service=service, x_maturity=x_maturity)
+
+    # By the time we are here, we either have a one selected
+    # x_maturity environments or None (if a specific x_maturity was set) or,
+    # if no such x_maturity preference, a catalog of (possibly one selected)
     # available 'x_maturity' environments from which to select for testing.
+
+    # We filter out the latter situation first...
+    if not server_urls:
+        return None
 
     # Now, we try to select one of the endpoints for testing
     testable_system: Optional[Tuple[str, str, Union[str, List[str]]]] = \
@@ -615,7 +717,38 @@ def validate_testable_resource(
     return resource_metadata
 
 
-def get_testable_resource_ids_from_registry(registry_data: Dict) -> Tuple[List[str], List[str]]:
+def get_testable_x_maturity_environments(metadata: Dict) -> List[str]:
+    test_data_location: Optional[Union[str, List, Dict]] = metadata['test_data_location']
+    return list()
+
+
+def get_resource_inventory():
+    raw_test_data_location: Optional[Union[str, Dict]] = tag_value(service, "info.x-trapi.test_data_location")
+
+    # ... and only interested in resources with a non-empty, valid, accessible test_data_location specified
+    test_data_location: Optional[Union[str, List, Dict]] = validate_test_data_locations(raw_test_data_location)
+    if test_data_location:
+        # Optional[Union[str, List, Dict]], may be a single URL string, an array of URL string's,
+        # or an x-maturity indexed catalog of URLs (single or List of URL string(s))
+        resource_metadata['test_data_location'] = test_data_location
+    else:
+        logger.warning(
+            f"Empty, invalid or inaccessible 'info.x-trapi.test_data_location' specification "
+            f"'{str(raw_test_data_location)}' for Registry entry '{infores}'! Service entry skipped?")
+        return None
+
+    servers: Optional[List[Dict]] = service['servers']
+
+    if not servers:
+        logger.warning(f"Registry entry '{infores}' missing a 'servers' block? Skipping...")
+        return None
+
+    server_urls: Dict = validate_servers(infores=infores, service=service, x_maturity=x_maturity)
+
+
+def get_testable_resources_from_registry(
+        registry_data: Dict
+) -> Tuple[Dict[str, List[str]], Dict[str, List[str]]]:
     """
     Simpler version of the extract_component_test_metadata_from_registry() method,
     that only returns the InfoRes reference identifiers of all testable resources.
@@ -624,11 +757,13 @@ def get_testable_resource_ids_from_registry(registry_data: Dict) -> Tuple[List[s
         Dict, Translator SmartAPI Registry dataset
         from which specific component_type metadata will be extracted.
 
-    :return: 2-Tuple(List[kp_id*], List[ara_id*]) of the reference id's of InfoRes CURIES of available KPs and ARAs.
+    :return: 2-Tuple(Dict[str, List[str]], Dict[str, List[str]]) dictionaries with keys
+             of the reference id's of InfoRes CURIES of available KPs and ARAs, with
+            value list of associated x-maturity environments available for testing.
     """
 
-    kp_ids: Set[str] = set()
-    ara_ids: Set[str] = set()
+    kp_ids: Dict[str, List[str]] = dict()
+    ara_ids: Dict[str, List[str]] = dict()
 
     for index, service in enumerate(registry_data['hits']):
 
@@ -637,46 +772,72 @@ def get_testable_resource_ids_from_registry(registry_data: Dict) -> Tuple[List[s
         if not (component and component in ["KP", "ARA"]):
             continue
 
-        resource_metadata: Optional[Dict[str, Any]] = \
-            validate_testable_resource(index, service, component)
-        if not resource_metadata:
+        resource: Optional[Tuple[str, List[str]]] = get_testable_resource(index, service)
+
+        if not resource:
             continue
 
+        infores: str = resource[0]
+
         if component == "KP":
-            kp_ids.add(resource_metadata['infores'])
+
+            if infores not in kp_ids:
+                kp_ids[infores] = list()
+
+            kp_ids[infores].extend(resource[1])
+
         elif component == "ARA":
-            ara_ids.add(resource_metadata['infores'])
 
-    return list(kp_ids), list(ara_ids)
+            if infores not in ara_ids:
+                ara_ids[infores] = list()
+
+            ara_ids[infores].extend(resource[1])
+
+    return kp_ids, ara_ids
 
 
-def source_of_interest(source: str, target_sources: Set[str]) -> bool:
+def source_of_interest(service: Dict, target_sources: Set[str]) -> Optional[str]:
     """
     Source filtering function, checking a source identifier against a set of identifiers.
     The target_source strings may also be wildcard patterns with a single asterix (only)
     with possible prefix only, suffix only or prefix-<body>-suffix matches.
-    :param source:
-    :param target_sources:
-    :return: bool, True if matched
+
+    :param service: Dict, Translator SmartAPI Registry entry for one service 'hit' containing an 'infores' property
+    :param target_sources: Set[str], set of target infores of interest
+    :return: Optional[str], infores if matched; None otherwise.
     """
-    assert source, "registry.source_of_interest() method call: unexpected empty infores?!?"
+    assert service, "registry.source_of_interest() method call: unexpected empty service?!?"
+
+    infores = tag_value(service, "info.x-translator.infores")
+
+    # Internally, within SRI Testing, we only track the object_id of the infores CURIE
+    infores = infores.replace("infores:", "") if infores else None
+
+    if not infores:
+        service_title = tag_value(service, "info.title")
+        logger.warning(f"Registry entry for '{str(service_title)}' has no 'infores' identifier. Skipping?")
+        return None
+
     if target_sources:
         found: bool = False
         for entry in target_sources:
+
             if entry.find("*") >= 0:
                 part = entry.split(sep="*", maxsplit=1)  # part should be a 2-tuple
-                if not part[0] or source.startswith(part[0]):
-                    if not part[1] or source.endswith(part[1]):
+                if not part[0] or infores.startswith(part[0]):
+                    if not part[1] or infores.endswith(part[1]):
                         found = True
                         break
-            elif source == entry:  # exact match?
+
+            elif infores == entry:  # exact match?
                 found = True
                 break
+
         if not found:
-            return False
+            return None
 
     # default if no target_sources or matching
-    return True
+    return infores
 
 
 # TODO: this is an ordered list giving 'production' testing priority
@@ -730,6 +891,14 @@ def extract_component_test_metadata_from_registry(
         if not (component and component == component_type):
             continue
 
+        # Filter on target sources of interest
+        infores: Optional[str] = source_of_interest(service=service, target_sources=target_sources)
+        if not infores:
+            # silently ignore any resource whose InfoRes CURIE
+            # reference identifier is missing or doesn't have a partial
+            # of exact match to a specified non-empty target source
+            continue
+
         resource_metadata: Optional[Dict[str, Any]] = \
             validate_testable_resource(index, service, component, x_maturity)
         if not resource_metadata:
@@ -738,7 +907,6 @@ def extract_component_test_metadata_from_registry(
         # Once past the 'testable resources' metadata gauntlet,
         # the following parameters are assumed valid and non-empty
         service_title: str = resource_metadata['service_title']
-        infores: str = resource_metadata['infores']
 
         # this 'url' is the service endpoint in the
         # specified 'x_maturity' environment
@@ -747,15 +915,8 @@ def extract_component_test_metadata_from_registry(
 
         # The 'test_data_location' also has url's but these are now expressed
         # in a polymorphic manner: Optional[Dict[str, Union[str, List, Dict]]].
-        # See validate_test_data_location above for details
+        # See validate_test_data_locations above for details
         test_data_location = resource_metadata['test_data_location']
-
-        # Filter on target sources of interest
-        if not source_of_interest(source=infores, target_sources=target_sources):
-            # silently ignore any resource whose InfoRes CURIE
-            # reference identifier that doesn't have a partial or
-            # exact match to a specified non-empty target source
-            continue
 
         # Now, we start to collect the remaining Registry metadata
 

--- a/translator/sri/testing/onehops_test_runner.py
+++ b/translator/sri/testing/onehops_test_runner.py
@@ -210,6 +210,7 @@ class OneHopTestHarness:
             self,
             ara_id: Optional[str] = None,
             kp_id: Optional[str] = None,
+            x_maturity: Optional[str] = None,
             trapi_version: Optional[str] = None,
             biolink_version: Optional[str] = None,
             one: bool = False,
@@ -225,6 +226,7 @@ class OneHopTestHarness:
             - Case 3 - non-empty ara_id, empty kp_id == validate against all the KPs specified by the ARA configuration
             - Case 4 - empty ara_id and kp_id, all Registry KPs and ARAs (long-running validation! Be careful now!)
 
+        :param x_maturity: Optional[str], x_maturity environment target for test run (system chooses if not specified)
         :param trapi_version: Optional[str], TRAPI version assumed for test run (default: None)
         :param biolink_version: Optional[str], Biolink Model version used in test run (default: None)
         :param one: bool, Only use first edge from each KP file (default: False if omitted).
@@ -253,6 +255,7 @@ class OneHopTestHarness:
         self._command_line += f" --biolink_version={biolink_version}" if biolink_version else ""
         self._command_line += f" --kp_id=\"{kp_id}\"" if kp_id else ""
         self._command_line += f" --ara_id=\"{ara_id}\"" if ara_id else ""
+        self._command_line += f" --x_maturity=\"{x_maturity}\"" if x_maturity else ""
         self._command_line += " --one" if one else ""
 
         logger.debug(f"OneHopTestHarness.run() command line: {self._command_line}")

--- a/translator/sri/testing/onehops_test_runner.py
+++ b/translator/sri/testing/onehops_test_runner.py
@@ -5,7 +5,7 @@ from typing import Optional, Dict, Tuple, List, Generator
 from datetime import datetime
 import re
 
-from translator.registry import get_the_registry_data, get_testable_resource_ids_from_registry
+from translator.registry import get_the_registry_data, get_testable_resources_from_registry
 from translator.sri.testing.processor import CMD_DELIMITER, WorkerTask
 
 from tests.onehop import ONEHOP_TEST_DIRECTORY
@@ -602,10 +602,22 @@ class OneHopTestHarness:
         return resource_summary
 
     @classmethod
-    def get_resources_from_registry(cls) -> Optional[Tuple[List[str], List[str]]]:
+    def testable_resources_catalog_from_registry(cls) -> Optional[Tuple[Dict[str, List[str]], Dict[str, List[str]]]]:
+        """
+        Retrieve inventory of testable resources from the Tranlator SmartAPI Registry.
+
+        :return: Optional 2-Tuple(Dict[ara_id*, List[str], Dict[kp_id*, List[str]) inventory of available
+                 KPs and ARAs,  with keys from reference ('object') id's of InfoRes CURIES and values that
+                 are lists of testable x-maturity environment tags. Return None if Registry is inaccessible.
+        """
+
         registry_data: Optional[Dict] = get_the_registry_data()
+
         if not registry_data:
             # Oops! Couldn't get any data out of the Registry?
             return None
-        resources: Tuple[List[str], List[str]] = get_testable_resource_ids_from_registry(registry_data)
+
+        resources: Tuple[Dict[str, List[str]], Dict[str, List[str]]] = \
+            get_testable_resources_from_registry(registry_data)
+
         return resources


### PR DESCRIPTION
- x-maturity awareness in /test_run propagated through to reports; test runs always just one endpoint from one x-maturity
- test_location_data associated with selected x-maturity; lists of test files merged into one consolidated set of test edges (but annotated as per test data knowledge source ('infores' in test data file)